### PR TITLE
Add 2-player tag mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,12 @@ uv run python -m pygbag --build .
 
 ## Architecture
 
-- **main.py** - Main entry point with game state machine (MENU → PLAYING → WON), async for pygbag web support
+- **main.py** - Main entry point with game state machine (MENU → PLAYING → WON, plus TAG_PLAYING → TAG_ROUND_END → TAG_GAME_OVER), async for pygbag web support
 - **maze.py** - `Maze` class with recursive backtracking generation, `Cell` dataclass for wall representation, `Difficulty` enum for presets
-- **player.py** - `Player` class with grid-based position and movement
-- **menu.py** - `Menu` class for difficulty selection screen
-- **config.py** - Display dimensions, colors, and constants
+- **player.py** - `Player` class with grid-based position, movement, and optional label drawing
+- **menu.py** - `Menu` class for mode/difficulty selection (Solo and Tag modes)
+- **tag_game.py** - `TagGame` class encapsulating 2-player tag mode state (scores, rounds, roles, countdown)
+- **config.py** - Display dimensions, colors, and constants (including tag mode colors/settings)
 - **utils.py** - Helper functions
 
 ## Key Concepts
@@ -54,18 +55,26 @@ uv run python -m pygbag --build .
 - Cell size is calculated dynamically based on window size and maze dimensions
 
 ### Game States
-- `GameState.MENU` - Difficulty selection
-- `GameState.PLAYING` - Active gameplay
-- `GameState.WON` - Win overlay displayed
+- `GameState.MENU` - Mode and difficulty selection
+- `GameState.PLAYING` - Active solo gameplay
+- `GameState.WON` - Solo win overlay displayed
+- `GameState.TAG_PLAYING` - Active 2-player tag gameplay
+- `GameState.TAG_ROUND_END` - Tag round result overlay
+- `GameState.TAG_GAME_OVER` - Tag final winner overlay
 
 ### Controls
-- Arrow keys or WASD: Move player
+- Arrow keys or WASD: Move player (solo mode)
 - W/S: Navigate menu (in addition to arrow keys)
-- Left/Right: Adjust settings values in menu
-- B: Toggle breadcrumb trail on/off (during gameplay)
+- Left/Right: Adjust settings values in menu (mode, shade, win score)
+- B: Toggle breadcrumb trail on/off (during solo gameplay)
 - R: Restart with new maze
 - ESC: Return to menu
-- Enter: Start game or toggle settings (from menu)
+- Enter: Start game or toggle settings (from menu), advance rounds (tag mode)
+
+### Tag Mode Controls
+- P1: WASD (always)
+- P2: Arrow keys (always)
+- Roles (tagger/runner) determine color and label, not controls
 
 ### Breadcrumb Trail
 - Optional visual trail showing the path taken through the maze
@@ -90,3 +99,14 @@ uv run python -m pygbag --build .
 - Displayed in upper left corner with retro 80's arcade font (Press Start 2P)
 - Resets on restart (R key) or new game from menu
 - Final move count displayed on win screen alongside time
+
+### Tag Mode
+- 2-player tag: one player is tagger ("IT"), the other is runner
+- Tagger (orange-red) tries to catch runner (sky blue) within 2-minute countdown
+- If tagged: tagger scores a point; if timeout: runner scores a point
+- Roles swap each round; first to N wins (configurable: 1, 3, or 5)
+- Mazes are Hard or Very Hard with extra loops for chase dynamics
+- HUD shows scores (upper-left), round number (upper-center), countdown (upper-right)
+- Countdown turns red when < 30 seconds remain
+- Round-end screen shows result, tagger moves, elapsed time, scores
+- Game-over screen shows winner with R to rematch, ESC for menu

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maze Game
 
-A maze game built with Pygame featuring random maze generation, multiple difficulty levels, and player navigation.
+A maze game built with Pygame featuring random maze generation, multiple difficulty levels, player navigation, and a 2-player tag mode.
 
 ## Features
 
@@ -10,8 +10,9 @@ A maze game built with Pygame featuring random maze generation, multiple difficu
 - **Path complexity control** - easier difficulties have more alternate paths
 - **Timer** - tracks solving time from first move, displayed in retro arcade font (MM:SS.T)
 - **Moves counter** - counts valid moves during gameplay, displayed alongside the timer
-- **Breadcrumb trail** - optional fading trail showing your path, with backtrack detection
+- **Breadcrumb trail** - optional fading trail showing your path, with backtrack detection and configurable shade (Light/Medium/Dark)
 - **Win screen** - shows final time and move count when the maze is solved
+- **2-player tag mode** - one player chases another through large mazes with loops (see below)
 
 ## Requirements
 
@@ -37,14 +38,32 @@ uv run python main.py
 
 ## Controls
 
+### Menu
+
 | Key | Action |
 |-----|--------|
-| Arrow keys / WASD | Move player |
-| B | Toggle breadcrumb trail on/off |
+| Up/Down or W/S | Navigate menu |
+| Left/Right | Switch game mode, adjust settings |
+| Enter | Start game or toggle setting |
+
+### Solo Mode
+
+| Key | Action |
+|-----|--------|
+| Arrow keys or WASD | Move player |
+| B | Toggle breadcrumb trail |
 | R | Restart with new maze |
 | ESC | Return to menu |
-| Enter | Start game / toggle settings (from menu) |
-| Left/Right | Adjust settings values (from menu) |
+
+### Tag Mode
+
+| Key | Action |
+|-----|--------|
+| WASD | Move Player 1 |
+| Arrow keys | Move Player 2 |
+| ESC | Return to menu |
+| Enter | Next round (round end) |
+| R | Rematch (game over) |
 
 ## Development
 
@@ -75,17 +94,20 @@ maze-game/
 ├── main.py          # Main entry point, game loop, state machine
 ├── maze.py          # Maze generation (recursive backtracking) & data structures
 ├── player.py        # Player state and movement
-├── menu.py          # Difficulty selection menu
+├── menu.py          # Mode/difficulty selection menu
+├── tag_game.py      # 2-player tag mode logic
 ├── config.py        # Game constants (dimensions, colors, etc.)
 ├── utils.py         # Helper functions
 ├── assets/fonts/    # Retro arcade font (Press Start 2P)
 ├── tests/           # Test suite
-│   ├── test_maze.py        # Maze unit tests
-│   ├── test_player.py      # Player unit tests
-│   ├── test_moves.py       # Moves counter tests
-│   ├── test_timer.py       # Timer tests
-│   ├── test_breadcrumbs.py # Breadcrumb trail tests
-│   └── test_integration.py # Integration tests
+│   ├── test_maze.py            # Maze unit tests
+│   ├── test_player.py          # Player unit tests
+│   ├── test_moves.py           # Moves counter tests
+│   ├── test_breadcrumbs.py     # Breadcrumb trail tests
+│   ├── test_timer.py           # Timer formatting tests
+│   ├── test_tag_game.py        # Tag mode unit tests
+│   ├── test_tag_integration.py # Tag mode integration tests
+│   └── test_integration.py     # Solo mode integration tests
 ├── pyproject.toml   # Project configuration
 └── README.md
 ```
@@ -110,6 +132,19 @@ Difficulty affects both maze size and complexity:
 ### Start/Goal Placement
 
 Start and goal positions are randomly placed with a minimum distance requirement (60% of the maximum possible path length) to ensure challenging gameplay.
+
+## Tag Mode
+
+Tag mode is a 2-player game where one player (the **tagger**) chases the other (the **runner**) through large mazes.
+
+- Select **Tag** mode from the menu using Left/Right on the mode selector
+- Choose **Hard** or **Very Hard** difficulty and a **First to N** win target (1, 3, or 5)
+- **Tagger** (orange-red, labeled "IT") tries to catch the **runner** (sky blue) within a 2-minute countdown
+- If tagged, the tagger scores a point; if time runs out, the runner scores
+- Roles swap each round; first player to the target score wins
+- Mazes have extra loops removed for better chase dynamics
+- Players start at maximally distant positions
+- HUD shows scores, round number, and countdown timer (turns red under 30s)
 
 ## License
 

--- a/config.py
+++ b/config.py
@@ -35,3 +35,10 @@ TIMER_FONT_PATH = "assets/fonts/PressStart2P-Regular.ttf"
 
 # moves counter
 MOVES_COLOR = PAC_COLOR
+
+# tag mode
+TAGGER_COLOR = (255, 69, 0)  # orange-red
+RUNNER_COLOR = (0, 191, 255)  # sky blue
+TAG_TIME_LIMIT = 120  # seconds per round
+TAG_LOOP_PERCENT = 10  # extra wall removal for chase dynamics
+TAG_WIN_SCORES = [1, 3, 5]  # selectable "first to N" options

--- a/main.py
+++ b/main.py
@@ -248,8 +248,6 @@ def draw_tag_round_end(surface: pygame.Surface, tag_game: TagGame) -> None:
     surface.blit(elapsed_text, elapsed_rect)
 
     # Scores
-    p1_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 1 else cfg.RUNNER_COLOR
-    p2_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 2 else cfg.RUNNER_COLOR
     score_text = font_medium.render(
         f"P1: {tag_game.scores[0]}  |  P2: {tag_game.scores[1]}", True, cfg.WHITE
     )

--- a/main.py
+++ b/main.py
@@ -204,9 +204,7 @@ def draw_tag_hud(surface: pygame.Surface, tag_game: TagGame) -> None:
     surface.blit(sep_text, (20 + p1_text.get_width() + 8, 10))
 
     p2_text = font.render(f"P2: {tag_game.scores[1]}", True, p2_color)
-    surface.blit(
-        p2_text, (20 + p1_text.get_width() + 8 + sep_text.get_width() + 8, 10)
-    )
+    surface.blit(p2_text, (20 + p1_text.get_width() + 8 + sep_text.get_width() + 8, 10))
 
     # Round number - upper center
     round_text = font.render(f"Round {tag_game.round_num}", True, cfg.WHITE)
@@ -436,9 +434,7 @@ async def main():
             elif state == GameState.TAG_GAME_OVER:
                 if event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_r:
-                        tag_game = TagGame(
-                            menu.tag_difficulty, menu.tag_win_score
-                        )
+                        tag_game = TagGame(menu.tag_difficulty, menu.tag_win_score)
                         tag_game.start_round()
                         state = GameState.TAG_PLAYING
                     elif event.key == pygame.K_ESCAPE:

--- a/main.py
+++ b/main.py
@@ -8,12 +8,16 @@ import config as cfg
 from maze import Maze
 from menu import Menu
 from player import Player
+from tag_game import TagGame
 
 
 class GameState(Enum):
     MENU = 1
     PLAYING = 2
     WON = 3
+    TAG_PLAYING = 4
+    TAG_ROUND_END = 5
+    TAG_GAME_OVER = 6
 
 
 pygame.init()
@@ -169,6 +173,130 @@ def draw_win_screen(surface: pygame.Surface, elapsed: float, move_count: int) ->
     surface.blit(hint_text, hint_rect)
 
 
+# --- Tag mode drawing functions ---
+
+
+def draw_tag_countdown(surface: pygame.Surface, remaining: float) -> None:
+    """Draw countdown timer in upper right corner."""
+    label = timer_font_label.render("TIME", True, cfg.TIMER_COLOR)
+    label_rect = label.get_rect(topright=(cfg.WIDTH - 20, 10))
+    surface.blit(label, label_rect)
+
+    time_str = format_time(remaining)
+    color = (255, 50, 50) if remaining < 30 else cfg.TIMER_COLOR
+    time_text = timer_font_time.render(time_str, True, color)
+    time_rect = time_text.get_rect(topright=(cfg.WIDTH - 20, 32))
+    surface.blit(time_text, time_rect)
+
+
+def draw_tag_hud(surface: pygame.Surface, tag_game: TagGame) -> None:
+    """Draw tag mode HUD: scores (upper-left), round (upper-center)."""
+    font = pygame.font.Font(None, 32)
+
+    # Scores - upper left
+    p1_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 1 else cfg.RUNNER_COLOR
+    p2_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 2 else cfg.RUNNER_COLOR
+
+    p1_text = font.render(f"P1: {tag_game.scores[0]}", True, p1_color)
+    surface.blit(p1_text, (20, 10))
+
+    sep_text = font.render("|", True, cfg.WHITE)
+    surface.blit(sep_text, (20 + p1_text.get_width() + 8, 10))
+
+    p2_text = font.render(f"P2: {tag_game.scores[1]}", True, p2_color)
+    surface.blit(
+        p2_text, (20 + p1_text.get_width() + 8 + sep_text.get_width() + 8, 10)
+    )
+
+    # Round number - upper center
+    round_text = font.render(f"Round {tag_game.round_num}", True, cfg.WHITE)
+    round_rect = round_text.get_rect(center=(cfg.WIDTH // 2, 22))
+    surface.blit(round_text, round_rect)
+
+
+def draw_tag_round_end(surface: pygame.Surface, tag_game: TagGame) -> None:
+    """Draw tag round-end overlay."""
+    overlay = pygame.Surface((cfg.WIDTH, cfg.HEIGHT), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 180))
+    surface.blit(overlay, (0, 0))
+
+    font_large = pygame.font.Font(None, 96)
+    font_medium = pygame.font.Font(None, 48)
+    font_small = pygame.font.Font(None, 32)
+
+    cy = cfg.HEIGHT // 2
+
+    # Result header
+    if tag_game.round_result == "tagged":
+        header = font_large.render("TAGGED!", True, cfg.TAGGER_COLOR)
+    else:
+        header = font_large.render("TIME'S UP!", True, cfg.RUNNER_COLOR)
+    header_rect = header.get_rect(center=(cfg.WIDTH // 2, cy - 100))
+    surface.blit(header, header_rect)
+
+    # Tagger moves and elapsed time
+    moves_text = font_small.render(
+        f"Tagger moves: {tag_game.tagger_moves}", True, cfg.WHITE
+    )
+    moves_rect = moves_text.get_rect(center=(cfg.WIDTH // 2, cy - 40))
+    surface.blit(moves_text, moves_rect)
+
+    elapsed_text = font_small.render(
+        f"Time: {format_time(tag_game.round_elapsed)}", True, cfg.WHITE
+    )
+    elapsed_rect = elapsed_text.get_rect(center=(cfg.WIDTH // 2, cy - 10))
+    surface.blit(elapsed_text, elapsed_rect)
+
+    # Scores
+    p1_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 1 else cfg.RUNNER_COLOR
+    p2_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 2 else cfg.RUNNER_COLOR
+    score_text = font_medium.render(
+        f"P1: {tag_game.scores[0]}  |  P2: {tag_game.scores[1]}", True, cfg.WHITE
+    )
+    score_rect = score_text.get_rect(center=(cfg.WIDTH // 2, cy + 40))
+    surface.blit(score_text, score_rect)
+
+    # Instructions
+    if tag_game.check_game_over():
+        hint = font_medium.render("Press ENTER to continue", True, cfg.WHITE)
+    else:
+        hint = font_medium.render("Press ENTER for next round", True, cfg.WHITE)
+    hint_rect = hint.get_rect(center=(cfg.WIDTH // 2, cy + 100))
+    surface.blit(hint, hint_rect)
+
+
+def draw_tag_game_over(surface: pygame.Surface, tag_game: TagGame) -> None:
+    """Draw tag game-over overlay."""
+    overlay = pygame.Surface((cfg.WIDTH, cfg.HEIGHT), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 200))
+    surface.blit(overlay, (0, 0))
+
+    font_large = pygame.font.Font(None, 96)
+    font_medium = pygame.font.Font(None, 48)
+
+    cy = cfg.HEIGHT // 2
+
+    winner = tag_game.check_game_over()
+    winner_color = cfg.TAGGER_COLOR if winner == 1 else cfg.RUNNER_COLOR
+
+    # Winner announcement
+    win_text = font_large.render(f"PLAYER {winner} WINS!", True, winner_color)
+    win_rect = win_text.get_rect(center=(cfg.WIDTH // 2, cy - 60))
+    surface.blit(win_text, win_rect)
+
+    # Final scores
+    score_text = font_medium.render(
+        f"P1: {tag_game.scores[0]}  |  P2: {tag_game.scores[1]}", True, cfg.WHITE
+    )
+    score_rect = score_text.get_rect(center=(cfg.WIDTH // 2, cy + 10))
+    surface.blit(score_text, score_rect)
+
+    # Instructions
+    hint = font_medium.render("R to play again, ESC for menu", True, cfg.WHITE)
+    hint_rect = hint.get_rect(center=(cfg.WIDTH // 2, cy + 80))
+    surface.blit(hint, hint_rect)
+
+
 async def main():
     running = True
     state = GameState.MENU
@@ -180,6 +308,7 @@ async def main():
     timer_start = None
     timer_end = None
     move_count = 0
+    tag_game = None
 
     while running:
         for event in pygame.event.get():
@@ -189,7 +318,7 @@ async def main():
             if state == GameState.MENU:
                 result = menu.handle_event(event)
                 if result == "start":
-                    # Start new game with selected difficulty
+                    # Start new solo game with selected difficulty
                     maze = Maze(menu.selected_difficulty)
                     maze.generate()
                     player = Player(maze.start_pos)
@@ -199,6 +328,11 @@ async def main():
                     timer_end = None
                     move_count = 0
                     state = GameState.PLAYING
+                elif result == "start_tag":
+                    # Start new tag game
+                    tag_game = TagGame(menu.tag_difficulty, menu.tag_win_score)
+                    tag_game.start_round()
+                    state = GameState.TAG_PLAYING
 
             elif state == GameState.PLAYING:
                 if event.type == pygame.KEYDOWN:
@@ -256,7 +390,68 @@ async def main():
                     elif event.key == pygame.K_ESCAPE:
                         state = GameState.MENU
 
-        # Draw based on state
+            elif state == GameState.TAG_PLAYING:
+                if event.type == pygame.KEYDOWN:
+                    # P1 controls: WASD
+                    p1_dir = None
+                    if event.key == pygame.K_a:
+                        p1_dir = "left"
+                    elif event.key == pygame.K_d:
+                        p1_dir = "right"
+                    elif event.key == pygame.K_w:
+                        p1_dir = "up"
+                    elif event.key == pygame.K_s:
+                        p1_dir = "down"
+
+                    if p1_dir:
+                        tag_game.process_move(1, p1_dir)
+
+                    # P2 controls: arrow keys
+                    p2_dir = None
+                    if event.key == pygame.K_LEFT:
+                        p2_dir = "left"
+                    elif event.key == pygame.K_RIGHT:
+                        p2_dir = "right"
+                    elif event.key == pygame.K_UP:
+                        p2_dir = "up"
+                    elif event.key == pygame.K_DOWN:
+                        p2_dir = "down"
+
+                    if p2_dir:
+                        tag_game.process_move(2, p2_dir)
+
+                    if event.key == pygame.K_ESCAPE:
+                        state = GameState.MENU
+
+            elif state == GameState.TAG_ROUND_END:
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_RETURN:
+                        if tag_game.check_game_over():
+                            state = GameState.TAG_GAME_OVER
+                        else:
+                            tag_game.swap_roles()
+                            tag_game.start_round()
+                            state = GameState.TAG_PLAYING
+                    elif event.key == pygame.K_ESCAPE:
+                        state = GameState.MENU
+
+            elif state == GameState.TAG_GAME_OVER:
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_r:
+                        tag_game = TagGame(
+                            menu.tag_difficulty, menu.tag_win_score
+                        )
+                        tag_game.start_round()
+                        state = GameState.TAG_PLAYING
+                    elif event.key == pygame.K_ESCAPE:
+                        state = GameState.MENU
+
+        # --- Check tag timeout every frame ---
+        if state == GameState.TAG_PLAYING and tag_game and tag_game.round_active:
+            if tag_game.check_timeout():
+                state = GameState.TAG_ROUND_END
+
+        # --- Draw based on state ---
         if state == GameState.MENU:
             menu.draw(display_surface)
 
@@ -289,6 +484,27 @@ async def main():
             draw_timer(display_surface, elapsed)
             draw_moves(display_surface, move_count)
             draw_win_screen(display_surface, elapsed, move_count)
+
+        elif state == GameState.TAG_PLAYING:
+            display_surface.fill(cfg.BLACK)
+            tag_game.maze.draw(display_surface, draw_markers=False)
+            tag_game.players[0].draw(display_surface, tag_game.maze, draw_label=True)
+            tag_game.players[1].draw(display_surface, tag_game.maze, draw_label=True)
+            draw_tag_hud(display_surface, tag_game)
+            draw_tag_countdown(display_surface, tag_game.get_remaining())
+
+        elif state == GameState.TAG_ROUND_END:
+            display_surface.fill(cfg.BLACK)
+            tag_game.maze.draw(display_surface, draw_markers=False)
+            tag_game.players[0].draw(display_surface, tag_game.maze, draw_label=True)
+            tag_game.players[1].draw(display_surface, tag_game.maze, draw_label=True)
+            draw_tag_hud(display_surface, tag_game)
+            draw_tag_countdown(display_surface, tag_game.get_remaining())
+            draw_tag_round_end(display_surface, tag_game)
+
+        elif state == GameState.TAG_GAME_OVER:
+            display_surface.fill(cfg.BLACK)
+            draw_tag_game_over(display_surface, tag_game)
 
         pygame.display.update()
         clock.tick(cfg.FPS)

--- a/main.py
+++ b/main.py
@@ -225,12 +225,19 @@ def draw_tag_round_end(surface: pygame.Surface, tag_game: TagGame) -> None:
     cy = cfg.HEIGHT // 2
 
     # Result header
+    runner_num = 2 if tag_game.tagger_player_num == 1 else 1
     if tag_game.round_result == "tagged":
         header = font_large.render("TAGGED!", True, cfg.TAGGER_COLOR)
+        scorer = font_medium.render(
+            f"P{tag_game.tagger_player_num} scores!", True, cfg.TAGGER_COLOR
+        )
     else:
         header = font_large.render("TIME'S UP!", True, cfg.RUNNER_COLOR)
+        scorer = font_medium.render(f"P{runner_num} survives!", True, cfg.RUNNER_COLOR)
     header_rect = header.get_rect(center=(cfg.WIDTH // 2, cy - 100))
     surface.blit(header, header_rect)
+    scorer_rect = scorer.get_rect(center=(cfg.WIDTH // 2, cy - 60))
+    surface.blit(scorer, scorer_rect)
 
     # Tagger moves and elapsed time
     moves_text = font_small.render(
@@ -415,6 +422,10 @@ async def main():
 
                     if p2_dir:
                         tag_game.process_move(2, p2_dir)
+
+                    # Check if a tag ended the round
+                    if not tag_game.round_active:
+                        state = GameState.TAG_ROUND_END
 
                     if event.key == pygame.K_ESCAPE:
                         state = GameState.MENU

--- a/main.py
+++ b/main.py
@@ -35,6 +35,9 @@ timer_font_time = pygame.font.Font(cfg.TIMER_FONT_PATH, 20)
 moves_font_label = pygame.font.Font(cfg.TIMER_FONT_PATH, 12)
 moves_font_value = pygame.font.Font(cfg.TIMER_FONT_PATH, 20)
 
+# Font for tag mode HUD
+tag_hud_font = pygame.font.Font(None, 32)
+
 
 def update_path(path: list[tuple[int, int]], new_pos: tuple[int, int]) -> None:
     """Update path history with backtrack detection."""
@@ -191,7 +194,7 @@ def draw_tag_countdown(surface: pygame.Surface, remaining: float) -> None:
 
 def draw_tag_hud(surface: pygame.Surface, tag_game: TagGame) -> None:
     """Draw tag mode HUD: scores (upper-left), round (upper-center)."""
-    font = pygame.font.Font(None, 32)
+    font = tag_hud_font
 
     # Scores - upper left
     p1_color = cfg.TAGGER_COLOR if tag_game.tagger_player_num == 1 else cfg.RUNNER_COLOR

--- a/maze.py
+++ b/maze.py
@@ -85,6 +85,12 @@ class Maze:
         """Remove additional walls to create loops (makes maze easier)."""
         if self.extra_removal <= 0:
             return
+        self.remove_extra_walls_percent(self.extra_removal)
+
+    def remove_extra_walls_percent(self, percent: int) -> None:
+        """Remove a percentage of internal walls to create loops."""
+        if percent <= 0:
+            return
 
         # Collect all internal walls
         internal_walls = []
@@ -96,7 +102,7 @@ class Maze:
                     internal_walls.append((row, col, "bottom", row + 1, col, "top"))
 
         # Remove a percentage of walls
-        num_to_remove = len(internal_walls) * self.extra_removal // 100
+        num_to_remove = len(internal_walls) * percent // 100
         walls_to_remove = random.sample(
             internal_walls, min(num_to_remove, len(internal_walls))
         )
@@ -104,6 +110,18 @@ class Maze:
         for r1, c1, wall1, r2, c2, wall2 in walls_to_remove:
             setattr(self.cells[r1][c1], wall1, False)
             setattr(self.cells[r2][c2], wall2, False)
+
+    def place_two_players(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        """Find two maximally distant positions using BFS."""
+        # Start BFS from a random cell to find the farthest cell
+        start = (random.randint(0, self.rows - 1), random.randint(0, self.cols - 1))
+        distances = self._bfs_distances(start)
+        # Farthest cell from the random start
+        pos1 = max(distances.items(), key=lambda x: x[1])[0]
+        # Farthest cell from pos1
+        distances2 = self._bfs_distances(pos1)
+        pos2 = max(distances2.items(), key=lambda x: x[1])[0]
+        return pos1, pos2
 
     def _place_start_and_goal(self) -> None:
         """Place start and goal at random positions with good distance."""
@@ -196,7 +214,9 @@ class Maze:
         y = cfg.MASTHEAD + cfg.PADDING + row * cell_size + cell_size / 2
         return (x, y)
 
-    def draw(self, surface: pygame.Surface, color: tuple = None) -> None:
+    def draw(
+        self, surface: pygame.Surface, color: tuple = None, draw_markers: bool = True
+    ) -> None:
         """Draw the maze walls on the given surface."""
         if color is None:
             color = cfg.MAZE_COLOR
@@ -234,6 +254,9 @@ class Maze:
                     pygame.draw.line(
                         surface, color, (x, y), (x, y + cell_size), line_width
                     )
+
+        if not draw_markers:
+            return
 
         # Draw start marker (green)
         start_x, start_y = self.grid_to_pixel(*self.start_pos)

--- a/menu.py
+++ b/menu.py
@@ -122,9 +122,9 @@ class Menu:
             tag_offset = self.selected_index - 1  # offset past mode selector
             win_idx = len(self.TAG_DIFFICULTIES)
             if tag_offset == win_idx:
-                self.tag_win_score_index = (
-                    self.tag_win_score_index + direction
-                ) % len(cfg.TAG_WIN_SCORES)
+                self.tag_win_score_index = (self.tag_win_score_index + direction) % len(
+                    cfg.TAG_WIN_SCORES
+                )
 
     def _handle_enter(self) -> str | None:
         """Handle enter key press."""
@@ -231,9 +231,7 @@ class Menu:
         color = cfg.PAC_COLOR if is_selected else cfg.WHITE
         prefix = "> " if is_selected else "  "
         on_off = "ON" if self.breadcrumbs_enabled else "OFF"
-        bc_text = self.font_medium.render(
-            f"{prefix}Breadcrumbs: {on_off}", True, color
-        )
+        bc_text = self.font_medium.render(f"{prefix}Breadcrumbs: {on_off}", True, color)
         bc_rect = bc_text.get_rect(center=(cfg.WIDTH // 2, settings_y + 50))
         surface.blit(bc_text, bc_rect)
 

--- a/menu.py
+++ b/menu.py
@@ -57,7 +57,8 @@ class Menu:
     def selected_difficulty(self) -> Difficulty:
         if self.game_mode == "Solo":
             # Offset by 1 for mode selector row
-            diff_index = max(0, min(self.selected_index - 1, len(self.DIFFICULTIES) - 1))
+            diff_index = min(self.selected_index - 1, len(self.DIFFICULTIES) - 1)
+            diff_index = max(0, diff_index)
             return self.DIFFICULTIES[diff_index][0]
         else:
             return self.tag_difficulty

--- a/menu.py
+++ b/menu.py
@@ -12,7 +12,14 @@ class Menu:
         (Difficulty.VERY_HARD, "Very Hard", "40x40 maze, maximum complexity"),
     ]
 
+    TAG_DIFFICULTIES = [
+        (Difficulty.HARD, "Hard", "30x30 maze"),
+        (Difficulty.VERY_HARD, "Very Hard", "40x40 maze"),
+    ]
+
     SHADES = ["Light", "Medium", "Dark"]
+
+    GAME_MODES = ["Solo", "Tag"]
 
     def __init__(self):
         self.selected_index = 0
@@ -24,14 +31,44 @@ class Menu:
         self.breadcrumbs_enabled = True
         self.shade_index = 1  # Default to Medium
 
-        # Navigation indices: difficulties first, then breadcrumbs toggle, then shade
-        self.menu_items_count = len(self.DIFFICULTIES) + 2
+        # Game mode state
+        self.game_mode_index = 0  # 0=Solo, 1=Tag
+
+        # Tag mode settings
+        self.tag_difficulty_index = 0  # index into TAG_DIFFICULTIES
+        self.tag_win_score_index = 1  # index into TAG_WIN_SCORES (default "3")
+
+        self._update_menu_items_count()
+
+    def _update_menu_items_count(self) -> None:
+        """Update menu item count based on current game mode."""
+        if self.game_mode == "Solo":
+            # mode selector + difficulties + breadcrumbs + shade
+            self.menu_items_count = 1 + len(self.DIFFICULTIES) + 2
+        else:
+            # mode selector + tag difficulties + first-to selector
+            self.menu_items_count = 1 + len(self.TAG_DIFFICULTIES) + 1
+
+    @property
+    def game_mode(self) -> str:
+        return self.GAME_MODES[self.game_mode_index]
 
     @property
     def selected_difficulty(self) -> Difficulty:
-        # Clamp to difficulty range in case we're on a settings item
-        diff_index = min(self.selected_index, len(self.DIFFICULTIES) - 1)
-        return self.DIFFICULTIES[diff_index][0]
+        if self.game_mode == "Solo":
+            # Offset by 1 for mode selector row
+            diff_index = max(0, min(self.selected_index - 1, len(self.DIFFICULTIES) - 1))
+            return self.DIFFICULTIES[diff_index][0]
+        else:
+            return self.tag_difficulty
+
+    @property
+    def tag_difficulty(self) -> Difficulty:
+        return self.TAG_DIFFICULTIES[self.tag_difficulty_index][0]
+
+    @property
+    def tag_win_score(self) -> int:
+        return cfg.TAG_WIN_SCORES[self.tag_win_score_index]
 
     @property
     def breadcrumb_opacity(self) -> int:
@@ -44,33 +81,76 @@ class Menu:
         return shade_map[self.shade_index]
 
     def handle_event(self, event: pygame.event.Event) -> str | None:
-        """Handle menu input. Returns 'start' if game should start."""
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_UP or event.key == pygame.K_w:
-                self.selected_index = (self.selected_index - 1) % self.menu_items_count
-            elif event.key == pygame.K_DOWN or event.key == pygame.K_s:
-                self.selected_index = (self.selected_index + 1) % self.menu_items_count
-            elif event.key == pygame.K_RETURN:
-                # If on a difficulty, start game
-                if self.selected_index < len(self.DIFFICULTIES):
-                    return "start"
-                # If on breadcrumbs toggle, toggle it
-                elif self.selected_index == len(self.DIFFICULTIES):
-                    self.breadcrumbs_enabled = not self.breadcrumbs_enabled
-                # If on shade, cycle through shades
-                elif self.selected_index == len(self.DIFFICULTIES) + 1:
-                    self.shade_index = (self.shade_index + 1) % len(self.SHADES)
-            elif event.key == pygame.K_LEFT or event.key == pygame.K_a:
-                # Left/right to adjust settings
-                if self.selected_index == len(self.DIFFICULTIES):
-                    self.breadcrumbs_enabled = not self.breadcrumbs_enabled
-                elif self.selected_index == len(self.DIFFICULTIES) + 1:
-                    self.shade_index = (self.shade_index - 1) % len(self.SHADES)
-            elif event.key == pygame.K_RIGHT or event.key == pygame.K_d:
-                if self.selected_index == len(self.DIFFICULTIES):
-                    self.breadcrumbs_enabled = not self.breadcrumbs_enabled
-                elif self.selected_index == len(self.DIFFICULTIES) + 1:
-                    self.shade_index = (self.shade_index + 1) % len(self.SHADES)
+        """Handle menu input. Returns 'start', 'start_tag', or None."""
+        if event.type != pygame.KEYDOWN:
+            return None
+
+        if event.key == pygame.K_UP or event.key == pygame.K_w:
+            self.selected_index = (self.selected_index - 1) % self.menu_items_count
+        elif event.key == pygame.K_DOWN or event.key == pygame.K_s:
+            self.selected_index = (self.selected_index + 1) % self.menu_items_count
+        elif event.key == pygame.K_LEFT or event.key == pygame.K_a:
+            self._handle_left_right(-1)
+        elif event.key == pygame.K_RIGHT or event.key == pygame.K_d:
+            self._handle_left_right(1)
+        elif event.key == pygame.K_RETURN:
+            return self._handle_enter()
+
+        return None
+
+    def _handle_left_right(self, direction: int) -> None:
+        """Handle left/right input for the current selection."""
+        # Row 0: mode selector
+        if self.selected_index == 0:
+            self.game_mode_index = (self.game_mode_index + direction) % len(
+                self.GAME_MODES
+            )
+            self.selected_index = 0
+            self._update_menu_items_count()
+            return
+
+        if self.game_mode == "Solo":
+            solo_offset = self.selected_index - 1  # offset past mode selector
+            bc_idx = len(self.DIFFICULTIES)
+            shade_idx = len(self.DIFFICULTIES) + 1
+            if solo_offset == bc_idx:
+                self.breadcrumbs_enabled = not self.breadcrumbs_enabled
+            elif solo_offset == shade_idx:
+                self.shade_index = (self.shade_index + direction) % len(self.SHADES)
+        else:
+            tag_offset = self.selected_index - 1  # offset past mode selector
+            win_idx = len(self.TAG_DIFFICULTIES)
+            if tag_offset == win_idx:
+                self.tag_win_score_index = (
+                    self.tag_win_score_index + direction
+                ) % len(cfg.TAG_WIN_SCORES)
+
+    def _handle_enter(self) -> str | None:
+        """Handle enter key press."""
+        # Row 0: mode selector toggles mode
+        if self.selected_index == 0:
+            self.game_mode_index = (self.game_mode_index + 1) % len(self.GAME_MODES)
+            self._update_menu_items_count()
+            return None
+
+        if self.game_mode == "Solo":
+            solo_offset = self.selected_index - 1
+            if solo_offset < len(self.DIFFICULTIES):
+                return "start"
+            elif solo_offset == len(self.DIFFICULTIES):
+                self.breadcrumbs_enabled = not self.breadcrumbs_enabled
+            elif solo_offset == len(self.DIFFICULTIES) + 1:
+                self.shade_index = (self.shade_index + 1) % len(self.SHADES)
+        else:
+            tag_offset = self.selected_index - 1
+            if tag_offset < len(self.TAG_DIFFICULTIES):
+                self.tag_difficulty_index = tag_offset
+                return "start_tag"
+            elif tag_offset == len(self.TAG_DIFFICULTIES):
+                self.tag_win_score_index = (self.tag_win_score_index + 1) % len(
+                    cfg.TAG_WIN_SCORES
+                )
+
         return None
 
     def draw(self, surface: pygame.Surface) -> None:
@@ -91,52 +171,74 @@ class Menu:
         inst_rect = instructions.get_rect(center=(cfg.WIDTH // 2, 140))
         surface.blit(instructions, inst_rect)
 
-        # Difficulty options
-        y_start = 200
+        y = 200
+
+        # Game mode selector (row 0)
+        is_selected = self.selected_index == 0
+        color = cfg.PAC_COLOR if is_selected else cfg.WHITE
+        prefix = "> " if is_selected else "  "
+        mode_text = self.font_medium.render(
+            f"{prefix}Mode: {self.game_mode}", True, color
+        )
+        mode_rect = mode_text.get_rect(center=(cfg.WIDTH // 2, y))
+        surface.blit(mode_text, mode_rect)
+        if is_selected:
+            hint = self.font_small.render(
+                "LEFT/RIGHT to switch mode", True, (200, 200, 200)
+            )
+            hint_rect = hint.get_rect(center=(cfg.WIDTH // 2, y + 25))
+            surface.blit(hint, hint_rect)
+
+        y += 60
+
+        if self.game_mode == "Solo":
+            self._draw_solo_options(surface, y)
+        else:
+            self._draw_tag_options(surface, y)
+
+    def _draw_solo_options(self, surface: pygame.Surface, y_start: int) -> None:
+        """Draw solo mode menu options."""
+        # Difficulty options (rows 1..4)
         for i, (diff, name, desc) in enumerate(self.DIFFICULTIES):
-            is_selected = i == self.selected_index
+            menu_idx = i + 1  # offset by mode selector
+            is_selected = menu_idx == self.selected_index
 
-            # Selection indicator
-            if is_selected:
-                color = cfg.PAC_COLOR
-                prefix = "> "
-            else:
-                color = cfg.WHITE
-                prefix = "  "
+            color = cfg.PAC_COLOR if is_selected else cfg.WHITE
+            prefix = "> " if is_selected else "  "
 
-            # Difficulty name
             text = self.font_medium.render(f"{prefix}{name}", True, color)
             text_rect = text.get_rect(center=(cfg.WIDTH // 2, y_start + i * 60))
             surface.blit(text, text_rect)
 
-            # Description
             desc_color = (200, 200, 200) if is_selected else (100, 100, 100)
             desc_text = self.font_small.render(desc, True, desc_color)
-            desc_y = y_start + i * 60 + 25
-            desc_rect = desc_text.get_rect(center=(cfg.WIDTH // 2, desc_y))
+            desc_rect = desc_text.get_rect(
+                center=(cfg.WIDTH // 2, y_start + i * 60 + 25)
+            )
             surface.blit(desc_text, desc_rect)
 
         # Settings section
         settings_y = y_start + len(self.DIFFICULTIES) * 60 + 40
 
-        # Settings header
         header = self.font_small.render("─── Settings ───", True, (150, 150, 150))
         header_rect = header.get_rect(center=(cfg.WIDTH // 2, settings_y))
         surface.blit(header, header_rect)
 
         # Breadcrumbs toggle
-        breadcrumb_idx = len(self.DIFFICULTIES)
-        is_selected = self.selected_index == breadcrumb_idx
+        bc_menu_idx = 1 + len(self.DIFFICULTIES)
+        is_selected = self.selected_index == bc_menu_idx
         color = cfg.PAC_COLOR if is_selected else cfg.WHITE
         prefix = "> " if is_selected else "  "
         on_off = "ON" if self.breadcrumbs_enabled else "OFF"
-        bc_text = self.font_medium.render(f"{prefix}Breadcrumbs: {on_off}", True, color)
+        bc_text = self.font_medium.render(
+            f"{prefix}Breadcrumbs: {on_off}", True, color
+        )
         bc_rect = bc_text.get_rect(center=(cfg.WIDTH // 2, settings_y + 50))
         surface.blit(bc_text, bc_rect)
 
         # Shade selector
-        shade_idx = len(self.DIFFICULTIES) + 1
-        is_selected = self.selected_index == shade_idx
+        shade_menu_idx = 1 + len(self.DIFFICULTIES) + 1
+        is_selected = self.selected_index == shade_menu_idx
         color = cfg.PAC_COLOR if is_selected else cfg.WHITE
         prefix = "> " if is_selected else "  "
         shade_name = self.SHADES[self.shade_index]
@@ -146,9 +248,57 @@ class Menu:
         shade_rect = shade_text.get_rect(center=(cfg.WIDTH // 2, settings_y + 100))
         surface.blit(shade_text, shade_rect)
 
-        # Controls hint at bottom
+        # Controls hint
         controls = self.font_small.render(
             "In game: WASD to move, B to toggle breadcrumbs, R restart, ESC menu",
+            True,
+            (100, 100, 100),
+        )
+        controls_rect = controls.get_rect(center=(cfg.WIDTH // 2, cfg.HEIGHT - 50))
+        surface.blit(controls, controls_rect)
+
+    def _draw_tag_options(self, surface: pygame.Surface, y_start: int) -> None:
+        """Draw tag mode menu options."""
+        # Difficulty options
+        for i, (diff, name, desc) in enumerate(self.TAG_DIFFICULTIES):
+            menu_idx = i + 1
+            is_selected = menu_idx == self.selected_index
+
+            color = cfg.PAC_COLOR if is_selected else cfg.WHITE
+            prefix = "> " if is_selected else "  "
+
+            text = self.font_medium.render(f"{prefix}{name}", True, color)
+            text_rect = text.get_rect(center=(cfg.WIDTH // 2, y_start + i * 60))
+            surface.blit(text, text_rect)
+
+            desc_color = (200, 200, 200) if is_selected else (100, 100, 100)
+            desc_text = self.font_small.render(desc, True, desc_color)
+            desc_rect = desc_text.get_rect(
+                center=(cfg.WIDTH // 2, y_start + i * 60 + 25)
+            )
+            surface.blit(desc_text, desc_rect)
+
+        # Settings section
+        settings_y = y_start + len(self.TAG_DIFFICULTIES) * 60 + 40
+
+        header = self.font_small.render("─── Settings ───", True, (150, 150, 150))
+        header_rect = header.get_rect(center=(cfg.WIDTH // 2, settings_y))
+        surface.blit(header, header_rect)
+
+        # First-to selector
+        win_menu_idx = 1 + len(self.TAG_DIFFICULTIES)
+        is_selected = self.selected_index == win_menu_idx
+        color = cfg.PAC_COLOR if is_selected else cfg.WHITE
+        prefix = "> " if is_selected else "  "
+        win_text = self.font_medium.render(
+            f"{prefix}First to: {self.tag_win_score}", True, color
+        )
+        win_rect = win_text.get_rect(center=(cfg.WIDTH // 2, settings_y + 50))
+        surface.blit(win_text, win_rect)
+
+        # Controls hint
+        controls = self.font_small.render(
+            "P1: WASD | P2: Arrows | Tagger catches runner!",
             True,
             (100, 100, 100),
         )

--- a/player.py
+++ b/player.py
@@ -4,7 +4,7 @@ import config as cfg
 
 
 class Player:
-    _label_font = None
+    _font_cache: dict[int, pygame.font.Font] = {}
 
     def __init__(
         self, start_pos: tuple[int, int], color: tuple = None, label: str = None
@@ -36,10 +36,10 @@ class Player:
         pygame.draw.circle(surface, self.color, (int(x), int(y)), radius)
 
         if draw_label and self.label:
-            if Player._label_font is None:
-                Player._label_font = pygame.font.Font(None, 20)
             font_size = max(10, int(cell_size / 3))
-            font = pygame.font.Font(None, font_size)
+            if font_size not in Player._font_cache:
+                Player._font_cache[font_size] = pygame.font.Font(None, font_size)
+            font = Player._font_cache[font_size]
             label_surface = font.render(self.label, True, cfg.WHITE)
             label_rect = label_surface.get_rect(center=(int(x), int(y) - radius - 6))
             surface.blit(label_surface, label_rect)

--- a/player.py
+++ b/player.py
@@ -4,9 +4,14 @@ import config as cfg
 
 
 class Player:
-    def __init__(self, start_pos: tuple[int, int], color: tuple = None):
+    _label_font = None
+
+    def __init__(
+        self, start_pos: tuple[int, int], color: tuple = None, label: str = None
+    ):
         self.row, self.col = start_pos
         self.color = color if color else cfg.PLAYER_COLOR
+        self.label = label
 
     @property
     def position(self) -> tuple[int, int]:
@@ -23,9 +28,18 @@ class Player:
         elif direction == "right":
             self.col += 1
 
-    def draw(self, surface: pygame.Surface, maze) -> None:
+    def draw(self, surface: pygame.Surface, maze, draw_label: bool = False) -> None:
         """Draw player at current grid position."""
         cell_size = maze.get_cell_size()
         x, y = maze.grid_to_pixel(self.row, self.col)
         radius = int(cell_size / 3)
         pygame.draw.circle(surface, self.color, (int(x), int(y)), radius)
+
+        if draw_label and self.label:
+            if Player._label_font is None:
+                Player._label_font = pygame.font.Font(None, 20)
+            font_size = max(10, int(cell_size / 3))
+            font = pygame.font.Font(None, font_size)
+            label_surface = font.render(self.label, True, cfg.WHITE)
+            label_rect = label_surface.get_rect(center=(int(x), int(y) - radius - 6))
+            surface.blit(label_surface, label_rect)

--- a/tag_game.py
+++ b/tag_game.py
@@ -127,7 +127,11 @@ class TagGame:
         self.round_active = False
         self.round_result = result
         if self.round_start_time is not None:
-            self.round_elapsed = time.time() - self.round_start_time
+            delta = time.time() - self.round_start_time
+            if result == "timeout":
+                self.round_elapsed = min(delta, cfg.TAG_TIME_LIMIT)
+            else:
+                self.round_elapsed = delta
 
         if result == "tagged":
             # Tagger wins the round

--- a/tag_game.py
+++ b/tag_game.py
@@ -1,0 +1,153 @@
+import time
+
+import config as cfg
+from maze import Difficulty, Maze
+from player import Player
+
+
+class TagGame:
+    """Encapsulates all state and logic for 2-player tag mode."""
+
+    def __init__(self, difficulty: Difficulty, win_score: int):
+        self.difficulty = difficulty
+        self.win_score = win_score
+        self.scores = [0, 0]  # [P1_score, P2_score]
+        self.round_num = 0
+        self.tagger_player_num = 1  # 1 or 2; who is "it"
+
+        # Per-round state (set in start_round)
+        self.maze: Maze | None = None
+        self.players: list[Player | None] = [None, None]  # index 0=P1, 1=P2
+        self.tagger_moves = 0
+        self.round_start_time: float | None = None
+        self.round_elapsed: float = 0.0
+        self.round_result: str | None = None  # "tagged" or "timeout"
+        self.round_active = False
+
+        # Future hook for power-ups
+        self.cell_effects: dict[tuple, str] = {}
+
+    def start_round(self) -> None:
+        """Initialize a new round with a fresh maze and player positions."""
+        self.round_num += 1
+        self.tagger_moves = 0
+        self.round_start_time = None
+        self.round_elapsed = 0.0
+        self.round_result = None
+        self.round_active = True
+        self.cell_effects = {}
+
+        # Generate maze with extra loops for chase dynamics
+        self.maze = Maze(self.difficulty)
+        self.maze.generate()
+        self.maze.remove_extra_walls_percent(cfg.TAG_LOOP_PERCENT)
+
+        # Place players at maximally distant positions
+        pos1, pos2 = self.maze.place_two_players()
+
+        # Assign colors and labels based on who is tagger
+        if self.tagger_player_num == 1:
+            self.players[0] = Player(pos1, color=cfg.TAGGER_COLOR, label="IT")
+            self.players[1] = Player(pos2, color=cfg.RUNNER_COLOR, label="P2")
+        else:
+            self.players[0] = Player(pos1, color=cfg.RUNNER_COLOR, label="P1")
+            self.players[1] = Player(pos2, color=cfg.TAGGER_COLOR, label="IT")
+
+    def process_move(self, player_num: int, direction: str) -> bool:
+        """Process a move for the given player (1 or 2).
+
+        Returns True if the move was valid and executed.
+        """
+        if not self.round_active or self.maze is None:
+            return False
+
+        player = self.players[player_num - 1]
+        if player is None:
+            return False
+
+        if not self.maze.is_valid_move(player.position, direction):
+            return False
+
+        # Start timer on first move of the round
+        if self.round_start_time is None:
+            self.round_start_time = time.time()
+
+        player.move(direction)
+
+        # Track tagger moves
+        if player_num == self.tagger_player_num:
+            self.tagger_moves += 1
+
+        # Check for cell effects (future hook)
+        pos = player.position
+        if pos in self.cell_effects:
+            pass  # Future: handle power-ups/glue/tunnels
+
+        # Check if tag occurred
+        if self.check_tag():
+            self.end_round("tagged")
+
+        return True
+
+    def check_tag(self) -> bool:
+        """Check if tagger and runner are on the same cell."""
+        if self.players[0] is None or self.players[1] is None:
+            return False
+        return self.players[0].position == self.players[1].position
+
+    def check_timeout(self) -> bool:
+        """Check if the round time limit has expired.
+
+        Returns True if timeout occurred and round was ended.
+        """
+        if not self.round_active or self.round_start_time is None:
+            return False
+
+        elapsed = time.time() - self.round_start_time
+        if elapsed >= cfg.TAG_TIME_LIMIT:
+            self.round_elapsed = cfg.TAG_TIME_LIMIT
+            self.end_round("timeout")
+            return True
+        return False
+
+    def get_elapsed(self) -> float:
+        """Get current elapsed time for the round."""
+        if self.round_start_time is None:
+            return 0.0
+        if not self.round_active:
+            return self.round_elapsed
+        return time.time() - self.round_start_time
+
+    def get_remaining(self) -> float:
+        """Get remaining time in the round."""
+        return max(0.0, cfg.TAG_TIME_LIMIT - self.get_elapsed())
+
+    def end_round(self, result: str) -> None:
+        """End the current round and award a point."""
+        self.round_active = False
+        self.round_result = result
+        if self.round_start_time is not None:
+            self.round_elapsed = time.time() - self.round_start_time
+
+        if result == "tagged":
+            # Tagger wins the round
+            self.scores[self.tagger_player_num - 1] += 1
+        elif result == "timeout":
+            # Runner wins the round (runner is the other player)
+            runner_num = 2 if self.tagger_player_num == 1 else 1
+            self.scores[runner_num - 1] += 1
+
+    def swap_roles(self) -> None:
+        """Swap tagger/runner roles for the next round."""
+        self.tagger_player_num = 2 if self.tagger_player_num == 1 else 1
+
+    def check_game_over(self) -> int | None:
+        """Check if a player has reached the win score.
+
+        Returns the winning player number (1 or 2), or None.
+        """
+        if self.scores[0] >= self.win_score:
+            return 1
+        if self.scores[1] >= self.win_score:
+            return 2
+        return None

--- a/tag_game.py
+++ b/tag_game.py
@@ -128,10 +128,7 @@ class TagGame:
         self.round_result = result
         if self.round_start_time is not None:
             delta = time.time() - self.round_start_time
-            if result == "timeout":
-                self.round_elapsed = min(delta, cfg.TAG_TIME_LIMIT)
-            else:
-                self.round_elapsed = delta
+            self.round_elapsed = min(delta, cfg.TAG_TIME_LIMIT)
 
         if result == "tagged":
             # Tagger wins the round

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -158,27 +158,28 @@ class TestMenuSettingsNavigation:
         pygame.quit()
 
     def test_menu_items_count_includes_settings(self):
-        """Menu should have difficulty options plus 2 settings."""
+        """Menu should have mode selector + difficulty options + 2 settings."""
         menu = Menu()
-        assert menu.menu_items_count == len(menu.DIFFICULTIES) + 2
+        # 1 (mode selector) + 4 difficulties + 2 settings = 7
+        assert menu.menu_items_count == 1 + len(menu.DIFFICULTIES) + 2
 
     def test_navigate_to_breadcrumb_toggle(self):
         """Should be able to navigate to breadcrumb toggle."""
         menu = Menu()
-        # Navigate down past difficulties
-        for _ in range(len(menu.DIFFICULTIES)):
+        # Navigate down past mode selector + difficulties
+        for _ in range(1 + len(menu.DIFFICULTIES)):
             event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_DOWN)
             menu.handle_event(event)
-        assert menu.selected_index == len(menu.DIFFICULTIES)
+        assert menu.selected_index == 1 + len(menu.DIFFICULTIES)
 
     def test_navigate_to_shade_selector(self):
         """Should be able to navigate to shade selector."""
         menu = Menu()
-        # Navigate down past difficulties and breadcrumb toggle
-        for _ in range(len(menu.DIFFICULTIES) + 1):
+        # Navigate down past mode selector + difficulties + breadcrumb toggle
+        for _ in range(1 + len(menu.DIFFICULTIES) + 1):
             event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_DOWN)
             menu.handle_event(event)
-        assert menu.selected_index == len(menu.DIFFICULTIES) + 1
+        assert menu.selected_index == 1 + len(menu.DIFFICULTIES) + 1
 
     def test_navigate_wraps_around(self):
         """Navigation should wrap from last item to first."""
@@ -191,7 +192,7 @@ class TestMenuSettingsNavigation:
     def test_enter_on_breadcrumb_toggles(self):
         """Enter on breadcrumb setting should toggle it."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES)  # Breadcrumb toggle
+        menu.selected_index = 1 + len(menu.DIFFICULTIES)  # Breadcrumb toggle
         initial = menu.breadcrumbs_enabled
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         menu.handle_event(event)
@@ -200,7 +201,7 @@ class TestMenuSettingsNavigation:
     def test_enter_on_shade_cycles(self):
         """Enter on shade setting should cycle to next shade."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES) + 1  # Shade selector
+        menu.selected_index = 1 + len(menu.DIFFICULTIES) + 1  # Shade selector
         menu.shade_index = 0
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         menu.handle_event(event)
@@ -209,7 +210,7 @@ class TestMenuSettingsNavigation:
     def test_left_on_breadcrumb_toggles(self):
         """Left arrow on breadcrumb setting should toggle it."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES)
+        menu.selected_index = 1 + len(menu.DIFFICULTIES)
         initial = menu.breadcrumbs_enabled
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_LEFT)
         menu.handle_event(event)
@@ -218,7 +219,7 @@ class TestMenuSettingsNavigation:
     def test_right_on_shade_cycles_forward(self):
         """Right arrow on shade setting should cycle forward."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES) + 1
+        menu.selected_index = 1 + len(menu.DIFFICULTIES) + 1
         menu.shade_index = 0
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT)
         menu.handle_event(event)
@@ -227,7 +228,7 @@ class TestMenuSettingsNavigation:
     def test_left_on_shade_cycles_backward(self):
         """Left arrow on shade setting should cycle backward."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES) + 1
+        menu.selected_index = 1 + len(menu.DIFFICULTIES) + 1
         menu.shade_index = 1
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_LEFT)
         menu.handle_event(event)
@@ -236,7 +237,7 @@ class TestMenuSettingsNavigation:
     def test_enter_on_difficulty_starts_game(self):
         """Enter on difficulty should return 'start'."""
         menu = Menu()
-        menu.selected_index = 0  # First difficulty
+        menu.selected_index = 1  # First difficulty (index 0 is mode selector)
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         result = menu.handle_event(event)
         assert result == "start"
@@ -244,7 +245,7 @@ class TestMenuSettingsNavigation:
     def test_enter_on_settings_does_not_start_game(self):
         """Enter on settings should not return 'start'."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES)  # Breadcrumb toggle
+        menu.selected_index = 1 + len(menu.DIFFICULTIES)  # Breadcrumb toggle
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         result = menu.handle_event(event)
         assert result is None
@@ -252,7 +253,7 @@ class TestMenuSettingsNavigation:
     def test_selected_difficulty_clamped_when_on_settings(self):
         """selected_difficulty should return last difficulty when on settings."""
         menu = Menu()
-        menu.selected_index = len(menu.DIFFICULTIES) + 1  # Shade selector
+        menu.selected_index = 1 + len(menu.DIFFICULTIES) + 1  # Shade selector
         # Should return the last difficulty, not error
         difficulty = menu.selected_difficulty
         assert difficulty == menu.DIFFICULTIES[-1][0]

--- a/tests/test_tag_game.py
+++ b/tests/test_tag_game.py
@@ -1,0 +1,306 @@
+"""Unit tests for the tag_game module."""
+
+import random
+from unittest.mock import patch
+
+import config as cfg
+from maze import Difficulty
+from tag_game import TagGame
+
+
+class TestTagGameInitialization:
+    """Tests for TagGame initialization."""
+
+    def test_initial_scores_zero(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        assert game.scores == [0, 0]
+
+    def test_initial_round_zero(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        assert game.round_num == 0
+
+    def test_initial_tagger_is_p1(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        assert game.tagger_player_num == 1
+
+    def test_win_score_stored(self):
+        game = TagGame(Difficulty.HARD, win_score=5)
+        assert game.win_score == 5
+
+    def test_difficulty_stored(self):
+        game = TagGame(Difficulty.VERY_HARD, win_score=1)
+        assert game.difficulty == Difficulty.VERY_HARD
+
+
+class TestStartRound:
+    """Tests for TagGame.start_round()."""
+
+    def test_round_number_increments(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.round_num == 1
+        game.round_active = False
+        game.start_round()
+        assert game.round_num == 2
+
+    def test_maze_created(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.maze is not None
+        assert game.maze.rows == 30
+        assert game.maze.cols == 30
+
+    def test_players_created(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.players[0] is not None
+        assert game.players[1] is not None
+
+    def test_players_at_different_positions(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.players[0].position != game.players[1].position
+
+    def test_tagger_has_correct_color_p1(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 1
+        game.start_round()
+        assert game.players[0].color == cfg.TAGGER_COLOR
+        assert game.players[0].label == "IT"
+        assert game.players[1].color == cfg.RUNNER_COLOR
+
+    def test_tagger_has_correct_color_p2(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 2
+        game.start_round()
+        assert game.players[1].color == cfg.TAGGER_COLOR
+        assert game.players[1].label == "IT"
+        assert game.players[0].color == cfg.RUNNER_COLOR
+
+    def test_tagger_moves_reset(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.tagger_moves == 0
+
+    def test_round_active(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.round_active is True
+
+
+class TestProcessMove:
+    """Tests for TagGame.process_move()."""
+
+    def test_valid_move_returns_true(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        p1 = game.players[0]
+        # Find a valid direction
+        for d in ["up", "down", "left", "right"]:
+            if game.maze.is_valid_move(p1.position, d):
+                assert game.process_move(1, d) is True
+                break
+
+    def test_invalid_move_returns_false(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        # All walls on boundary should fail for certain directions
+        assert game.process_move(1, "invalid_dir") is False
+
+    def test_tagger_moves_counted(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        p1 = game.players[0]
+        # P1 is tagger, find valid move
+        for d in ["up", "down", "left", "right"]:
+            if game.maze.is_valid_move(p1.position, d):
+                game.process_move(1, d)
+                break
+        assert game.tagger_moves == 1
+
+    def test_runner_moves_not_counted_as_tagger(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        p2 = game.players[1]
+        for d in ["up", "down", "left", "right"]:
+            if game.maze.is_valid_move(p2.position, d):
+                game.process_move(2, d)
+                break
+        assert game.tagger_moves == 0
+
+    def test_move_when_not_active_returns_false(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_active = False
+        assert game.process_move(1, "up") is False
+
+
+class TestCheckTag:
+    """Tests for TagGame.check_tag()."""
+
+    def test_different_positions_no_tag(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.check_tag() is False
+
+    def test_same_position_is_tag(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        # Force players to same position
+        game.players[1].row = game.players[0].row
+        game.players[1].col = game.players[0].col
+        assert game.check_tag() is True
+
+
+class TestEndRound:
+    """Tests for TagGame.end_round()."""
+
+    def test_tagged_awards_tagger(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 1
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1010.0):
+            game.end_round("tagged")
+        assert game.scores == [1, 0]
+
+    def test_timeout_awards_runner(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 1
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1120.0):
+            game.end_round("timeout")
+        assert game.scores == [0, 1]
+
+    def test_round_deactivated(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1010.0):
+            game.end_round("tagged")
+        assert game.round_active is False
+
+    def test_result_stored(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1010.0):
+            game.end_round("timeout")
+        assert game.round_result == "timeout"
+
+
+class TestSwapRoles:
+    """Tests for TagGame.swap_roles()."""
+
+    def test_swap_from_p1_to_p2(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        assert game.tagger_player_num == 1
+        game.swap_roles()
+        assert game.tagger_player_num == 2
+
+    def test_swap_from_p2_to_p1(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 2
+        game.swap_roles()
+        assert game.tagger_player_num == 1
+
+    def test_double_swap_returns_to_original(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.swap_roles()
+        game.swap_roles()
+        assert game.tagger_player_num == 1
+
+
+class TestCheckGameOver:
+    """Tests for TagGame.check_game_over()."""
+
+    def test_no_winner_at_start(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        assert game.check_game_over() is None
+
+    def test_p1_wins(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.scores = [3, 1]
+        assert game.check_game_over() == 1
+
+    def test_p2_wins(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.scores = [2, 3]
+        assert game.check_game_over() == 2
+
+    def test_no_winner_below_threshold(self):
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.scores = [2, 2]
+        assert game.check_game_over() is None
+
+    def test_win_score_1(self):
+        game = TagGame(Difficulty.HARD, win_score=1)
+        game.scores = [1, 0]
+        assert game.check_game_over() == 1
+
+
+class TestCheckTimeout:
+    """Tests for TagGame.check_timeout()."""
+
+    def test_no_timeout_before_start(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        # Timer not started yet
+        assert game.check_timeout() is False
+
+    def test_no_timeout_within_limit(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1060.0):
+            assert game.check_timeout() is False
+
+    def test_timeout_after_limit(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1121.0):
+            assert game.check_timeout() is True
+        assert game.round_result == "timeout"
+        assert game.round_active is False
+
+
+class TestGetRemaining:
+    """Tests for TagGame.get_remaining()."""
+
+    def test_full_time_before_start(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        assert game.get_remaining() == cfg.TAG_TIME_LIMIT
+
+    def test_remaining_decreases(self):
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1030.0):
+            assert game.get_remaining() == cfg.TAG_TIME_LIMIT - 30.0

--- a/tests/test_tag_integration.py
+++ b/tests/test_tag_integration.py
@@ -210,9 +210,7 @@ class TestMazeTagFeatures:
         standard_walls = 0
         for row in maze_standard.cells:
             for cell in row:
-                standard_walls += sum(
-                    [cell.top, cell.right, cell.bottom, cell.left]
-                )
+                standard_walls += sum([cell.top, cell.right, cell.bottom, cell.left])
 
         # Generate tag maze (same difficulty + extra loop removal)
         random.seed(42)

--- a/tests/test_tag_integration.py
+++ b/tests/test_tag_integration.py
@@ -1,0 +1,230 @@
+"""Integration tests for tag mode."""
+
+import random
+from collections import deque
+from unittest.mock import patch
+
+import config as cfg
+from maze import Difficulty
+from tag_game import TagGame
+
+
+def _find_path_bfs(maze, start_pos, goal_pos):
+    """Find path from start to goal using BFS. Returns list of directions."""
+    visited = {start_pos}
+    queue = deque([(start_pos, [])])
+
+    while queue:
+        pos, path = queue.popleft()
+        if pos == goal_pos:
+            return path
+
+        for direction in ["up", "down", "left", "right"]:
+            if maze.is_valid_move(pos, direction):
+                row, col = pos
+                if direction == "up":
+                    new_pos = (row - 1, col)
+                elif direction == "down":
+                    new_pos = (row + 1, col)
+                elif direction == "left":
+                    new_pos = (row, col - 1)
+                else:
+                    new_pos = (row, col + 1)
+
+                if new_pos not in visited:
+                    visited.add(new_pos)
+                    queue.append((new_pos, path + [direction]))
+
+    return None
+
+
+class TestTagGameFullRound:
+    """Test a full tag round where tagger catches runner."""
+
+    def test_tagger_catches_runner(self):
+        """Tagger should be able to navigate to runner and tag them."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+
+        tagger_idx = game.tagger_player_num - 1
+        runner_idx = 1 - tagger_idx
+
+        tagger_pos = game.players[tagger_idx].position
+        runner_pos = game.players[runner_idx].position
+
+        # Find path from tagger to runner
+        path = _find_path_bfs(game.maze, tagger_pos, runner_pos)
+        assert path is not None, "Tagger should be able to reach runner"
+
+        # Move tagger along the path
+        for direction in path[:-1]:  # Stop one before the end
+            game.process_move(game.tagger_player_num, direction)
+            assert game.round_active, "Round should still be active"
+
+        # Last move should trigger tag
+        game.process_move(game.tagger_player_num, path[-1])
+        assert not game.round_active
+        assert game.round_result == "tagged"
+        assert game.scores[tagger_idx] == 1
+
+    def test_both_players_can_move(self):
+        """Both P1 and P2 should be able to move independently."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+
+        p1_start = game.players[0].position
+        p2_start = game.players[1].position
+
+        # Find valid moves for each player
+        p1_moved = False
+        for d in ["up", "down", "left", "right"]:
+            if game.maze.is_valid_move(p1_start, d):
+                game.process_move(1, d)
+                p1_moved = True
+                break
+
+        p2_moved = False
+        for d in ["up", "down", "left", "right"]:
+            if game.maze.is_valid_move(p2_start, d):
+                game.process_move(2, d)
+                p2_moved = True
+                break
+
+        assert p1_moved, "P1 should have at least one valid move"
+        assert p2_moved, "P2 should have at least one valid move"
+        assert game.players[0].position != p1_start
+        assert game.players[1].position != p2_start
+
+
+class TestTagGameMultipleRounds:
+    """Test multiple round progression with role swapping."""
+
+    def test_roles_swap_between_rounds(self):
+        """Tagger/runner roles should swap after each round."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+
+        assert game.tagger_player_num == 1
+
+        game.start_round()
+        game.round_start_time = 1000.0
+        with patch("tag_game.time.time", return_value=1010.0):
+            game.end_round("tagged")
+
+        game.swap_roles()
+        assert game.tagger_player_num == 2
+
+        game.start_round()
+        # P2 should now be tagger (orange-red with "IT" label)
+        assert game.players[1].color == cfg.TAGGER_COLOR
+        assert game.players[1].label == "IT"
+        assert game.players[0].color == cfg.RUNNER_COLOR
+
+    def test_game_ends_at_win_score(self):
+        """Game should end when a player reaches the win score."""
+        game = TagGame(Difficulty.HARD, win_score=2)
+
+        # Simulate P1 winning 2 rounds
+        game.scores = [2, 0]
+        assert game.check_game_over() == 1
+
+    def test_full_game_to_completion(self):
+        """Simulate a full game from start to game over."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=1)
+        game.start_round()
+
+        tagger_idx = game.tagger_player_num - 1
+        runner_idx = 1 - tagger_idx
+
+        # Move tagger to runner
+        path = _find_path_bfs(
+            game.maze,
+            game.players[tagger_idx].position,
+            game.players[runner_idx].position,
+        )
+        for direction in path:
+            game.process_move(game.tagger_player_num, direction)
+
+        assert game.round_result == "tagged"
+        assert game.check_game_over() is not None
+
+
+class TestTagTimeout:
+    """Test timeout scenarios."""
+
+    def test_timeout_awards_runner(self):
+        """When time expires, the runner should score."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.tagger_player_num = 1
+        game.start_round()
+
+        # Simulate timer start
+        game.round_start_time = 1000.0
+        # Simulate timeout
+        with patch("tag_game.time.time", return_value=1000.0 + cfg.TAG_TIME_LIMIT + 1):
+            timed_out = game.check_timeout()
+
+        assert timed_out
+        assert game.round_result == "timeout"
+        # Runner is P2 when tagger is P1
+        assert game.scores == [0, 1]
+
+
+class TestMazeTagFeatures:
+    """Test maze features specific to tag mode."""
+
+    def test_players_placed_far_apart(self):
+        """Players should be placed at maximally distant positions."""
+        random.seed(42)
+        game = TagGame(Difficulty.HARD, win_score=3)
+        game.start_round()
+
+        p1_pos = game.players[0].position
+        p2_pos = game.players[1].position
+
+        # Calculate BFS distance between players
+        distances = game.maze._bfs_distances(p1_pos)
+        player_dist = distances[p2_pos]
+
+        # Should be reasonably far apart (at least 30% of max distance)
+        max_dist = max(distances.values())
+        assert player_dist >= max_dist * 0.3, (
+            f"Players too close: dist={player_dist}, max={max_dist}"
+        )
+
+    def test_tag_maze_has_extra_loops(self):
+        """Tag mode mazes should have extra walls removed for more loops."""
+        random.seed(42)
+
+        # Generate standard Hard maze
+        from maze import Maze
+
+        maze_standard = Maze(Difficulty.HARD)
+        maze_standard.generate()
+
+        # Count walls in standard maze
+        standard_walls = 0
+        for row in maze_standard.cells:
+            for cell in row:
+                standard_walls += sum(
+                    [cell.top, cell.right, cell.bottom, cell.left]
+                )
+
+        # Generate tag maze (same difficulty + extra loop removal)
+        random.seed(42)
+        maze_tag = Maze(Difficulty.HARD)
+        maze_tag.generate()
+        maze_tag.remove_extra_walls_percent(cfg.TAG_LOOP_PERCENT)
+
+        # Count walls in tag maze
+        tag_walls = 0
+        for row in maze_tag.cells:
+            for cell in row:
+                tag_walls += sum([cell.top, cell.right, cell.bottom, cell.left])
+
+        # Tag maze should have fewer walls
+        assert tag_walls < standard_walls


### PR DESCRIPTION
## Summary

- Adds a 2-player tag game mode where a tagger chases a runner through large mazes with loops
- Menu updated with Solo/Tag mode selector; tag mode offers Hard/Very Hard difficulty and configurable win score (first to 1/3/5)
- New `TagGame` class encapsulating scores, rounds, role-swapping, 2-minute countdown, and move tracking
- Three new game states (`TAG_PLAYING`, `TAG_ROUND_END`, `TAG_GAME_OVER`) with HUD, countdown, and overlay screens
- P1 always uses WASD, P2 always uses arrow keys; tagger is orange-red with "IT" label, runner is sky blue
- Maze enhancements: `place_two_players()` for max-distance placement, `remove_extra_walls_percent()` for chase dynamics
- **Fix:** Tag mode no longer hangs when tagger catches runner — added missing state transition from `TAG_PLAYING` to `TAG_ROUND_END` after `process_move()` detects a tag
- **UX:** Round-end overlay now shows who scored ("P1 scores!" / "P2 survives!")
- **Fix:** Timeout elapsed time clamped to TAG_TIME_LIMIT in `end_round()` so displayed time never exceeds 2:00
- **Perf:** Player label fonts cached by size instead of recreated every frame
- Rebased onto main (includes moves counter feature)
- 37 new unit tests + 8 integration tests (136 total, all passing)

Closes #8

## Test plan

- [x] `uv run pytest` — all 136 tests pass, no regressions
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Manual: solo mode works exactly as before (moves counter + timer intact)
- [x] Manual: select Tag mode, choose Hard, First to 3, start game
- [x] Manual: P1 (WASD) and P2 (arrows) move independently
- [x] Manual: tagger catches runner → "TAGGED!" overlay with scorer info + ENTER prompt
- [x] Manual: timer expires → "TIME'S UP!" overlay with survivor info
- [x] Manual: roles swap each round, scores accumulate
- [x] Manual: first to target score → game over screen with R/ESC options

🤖 Generated with [Claude Code](https://claude.com/claude-code)